### PR TITLE
Always Float Labels

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "money-input",
   "description": "`money-input` is a customizable input validator and mask for currency amounts.",
   "main": "money-input.html",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "homepage": "https://ingressorapidowebcomponents.github.io/components/money-input",
   "dependencies": {
     "polymer": "Polymer/polymer#^1.4.0",

--- a/money-input.html
+++ b/money-input.html
@@ -52,7 +52,8 @@ Custom property | Description | Default
             name$="[[name]]"
             allowed-pattern="[0-9\.\,\-]"
             disabled$="[[disabled]]"
-            readonly$="[[readonly]]">
+            readonly$="[[readonly]]"
+            always-float-label$="[[alwaysFloatLabel]]">
       <div prefix class="prefix">[[currency]]</div>
     </paper-input>
   </template>
@@ -153,6 +154,15 @@ Custom property | Description | Default
         decimalSymbol: {
           type: String,
           value: "."
+        },
+
+        /** 
+         * Boolean which indicates if the label should always float above
+         * the input box
+         */
+        alwaysFloatLabel: {
+          type: Boolean,
+          value: false
         }
       },
 


### PR DESCRIPTION
## Summary

This is a simple change which passes 'always-float-label' through to paper-input. If omitted then default behaviour is utilized.
## Example Usage

`<money-input label="Money" value="{{money}}" required always-float-label></money-input>`
