### PR TITLE
No label float

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 
 .git/
 .idea/
+.directory
 bower_components/

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,10 +4,10 @@
     <title>money-input demo</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
 
-    <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
-    <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+    <link rel="import" href="../bower_components/iron-demo-helpers/demo-pages-shared-styles.html">
+    <link rel="import" href="../bower_components/iron-demo-helpers/demo-snippet.html">
 
     <link rel="import" href="../money-input.html">
 
@@ -35,6 +35,13 @@
       <demo-snippet>
         <template>
           <money-input max-value="99" value="4" precision="0" min-value="2"></money-input>
+        </template>
+      </demo-snippet>
+
+      <h3>noLableFloat</h3>
+      <demo-snippet>
+        <template>
+          <money-input no-label-float max-value="2" value="600"></money-input>
         </template>
       </demo-snippet>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,10 +4,10 @@
     <title>money-input demo</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-    <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
-    <link rel="import" href="../bower_components/iron-demo-helpers/demo-pages-shared-styles.html">
-    <link rel="import" href="../bower_components/iron-demo-helpers/demo-snippet.html">
+    <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
+    <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
 
     <link rel="import" href="../money-input.html">
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -38,10 +38,10 @@
         </template>
       </demo-snippet>
 
-      <h3>noLableFloat</h3>
+      <h3>noLabelFloat</h3>
       <demo-snippet>
         <template>
-          <money-input no-label-float max-value="2" value="600"></money-input>
+          <money-input no-label-float value="600"></money-input>
         </template>
       </demo-snippet>
 

--- a/money-input.html
+++ b/money-input.html
@@ -8,9 +8,9 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="bower_components/polymer/polymer.html">
-<link rel="import" href="bower_components/paper-input/paper-input.html">
-<link rel="import" href="bower_components/paper-input/paper-input-error.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../paper-input/paper-input.html">
+<link rel="import" href="../paper-input/paper-input-error.html">
 
 <!--
 `<money-input>` is a customizable input validator and mask for currency amounts.

--- a/money-input.html
+++ b/money-input.html
@@ -8,9 +8,9 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../paper-input/paper-input.html">
-<link rel="import" href="../paper-input/paper-input-error.html">
+<link rel="import" href="bower_components/polymer/polymer.html">
+<link rel="import" href="bower_components/paper-input/paper-input.html">
+<link rel="import" href="bower_components/paper-input/paper-input-error.html">
 
 <!--
 `<money-input>` is a customizable input validator and mask for currency amounts.
@@ -47,6 +47,7 @@ Custom property | Description | Default
     <paper-input
             id="input"
             label="[[label]]"
+            no-label-float="[[noLabelFloat]]"
             required$="[[required]]"
             value="{{_formattedValue}}"
             name$="[[name]]"
@@ -98,6 +99,12 @@ Custom property | Description | Default
         label: {
           type: String,
           value: 'Amount'
+        },
+
+        /** Disables the floating label */
+        noLabelFloat: {
+          type: Boolean,
+          value: false
         },
 
         /** Presets field value notifies new values */


### PR DESCRIPTION
Added missing noLabelFloat property, so one can hide the floating label by using the no-label-float-attribute.

Modified demo/index.html code to show a sample noLabelFloat example.

Issue: #4 
