### PR TITLE
Show zeros and process integers according to precision.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 
 .git/
 .idea/
+.directory
 bower_components/

--- a/demo/index.html
+++ b/demo/index.html
@@ -20,14 +20,21 @@
       <h3>Basic</h3>
       <demo-snippet>
         <template>
-          <money-input></money-input>
+          <money-input value="0"></money-input>
+        </template>
+      </demo-snippet>
+
+      <h3>Negative</h3>
+      <demo-snippet>
+        <template>
+          <money-input value="-5.66"></money-input>
         </template>
       </demo-snippet>
 
       <h3>Preset/Error</h3>
       <demo-snippet>
         <template>
-          <money-input max-value="2" value="4.00"></money-input>
+          <money-input max-value="2" min-value="1" value="5.66"></money-input>
         </template>
       </demo-snippet>
 
@@ -41,7 +48,7 @@
       <h3>noLableFloat</h3>
       <demo-snippet>
         <template>
-          <money-input no-label-float max-value="2" value="600"></money-input>
+          <money-input no-label-float max-value="2" value="-600"></money-input>
         </template>
       </demo-snippet>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -48,7 +48,7 @@
       <h3>noLableFloat</h3>
       <demo-snippet>
         <template>
-          <money-input no-label-float max-value="2" value="-600"></money-input>
+          <money-input no-label-float value="600"></money-input>
         </template>
       </demo-snippet>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -41,7 +41,7 @@
       <h3>Precision 0</h3>
       <demo-snippet>
         <template>
-          <money-input max-value="99" value="4" precision="0" min-value="2"></money-input>
+          <money-input max-value="99" value="4" precision="0"></money-input>
         </template>
       </demo-snippet>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -45,7 +45,7 @@
         </template>
       </demo-snippet>
 
-      <h3>noLableFloat</h3>
+      <h3>noLableFloat & Decimal w/ lots of digits</h3>
       <demo-snippet>
         <template>
           <money-input no-label-float value="600.999999956"></money-input>

--- a/demo/index.html
+++ b/demo/index.html
@@ -48,7 +48,7 @@
       <h3>noLableFloat</h3>
       <demo-snippet>
         <template>
-          <money-input no-label-float value="600"></money-input>
+          <money-input no-label-float value="600.999999956"></money-input>
         </template>
       </demo-snippet>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,10 +4,10 @@
     <title>money-input demo</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
 
-    <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
-    <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+    <link rel="import" href="../bower_components/iron-demo-helpers/demo-pages-shared-styles.html">
+    <link rel="import" href="../bower_components/iron-demo-helpers/demo-snippet.html">
 
     <link rel="import" href="../money-input.html">
 
@@ -35,6 +35,13 @@
       <demo-snippet>
         <template>
           <money-input max-value="99" value="4" precision="0" min-value="2"></money-input>
+        </template>
+      </demo-snippet>
+
+      <h3>noLableFloat</h3>
+      <demo-snippet>
+        <template>
+          <money-input no-label-float max-value="2" value="600"></money-input>
         </template>
       </demo-snippet>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,10 +4,10 @@
     <title>money-input demo</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-    <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
-    <link rel="import" href="../bower_components/iron-demo-helpers/demo-pages-shared-styles.html">
-    <link rel="import" href="../bower_components/iron-demo-helpers/demo-snippet.html">
+    <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
+    <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
 
     <link rel="import" href="../money-input.html">
 

--- a/money-input.html
+++ b/money-input.html
@@ -173,17 +173,14 @@ Custom property | Description | Default
 
       /** You can use this to re-render the input */
       renderElement: function(){
-        console.log('renderElement');
 
         this.$.input.invalid = false;
 
         if(this.value && !this._formattedValue) {
-          console.log('from renderElement');
           this._valuePreProcessing();
         }
 
         this._setValue = function (f) {
-          console.log('_setValue');
 
           if(this._formattedValue) {
             var signal = this._formattedValue.indexOf("\-") >= 0 ? "-" : "";
@@ -210,7 +207,7 @@ Custom property | Description | Default
         var completeNumber = undefined;
 
         if (decFraction == 0 && this.precision != 0) {
-          console.log('they fed me an Integer');
+          //console.log('they fed me an Integer');
           completeNumber = signal + value + ".00";
         }
         else {
@@ -222,11 +219,9 @@ Custom property | Description | Default
       },
 
       _valueChange: function(){
-        console.log('_valueChange');
 
         if((this.value || this.value === 0 || this.value === '0') &&
             (this._formattedValue!= this.value || this.value === 0 || this.value === '0')) {
-          console.log('from _valueChange');
 
           this._valuePreProcessing();
         }

--- a/money-input.html
+++ b/money-input.html
@@ -213,25 +213,20 @@ Custom property | Description | Default
           integer = Number(this.value) - Number(decFraction);
           completeNumber = (integer + decFraction);
 
-          console.log(completeNumber);
-
           completeNumber = completeNumber + '';
           var respFraction = completeNumber.split('.');
-          console.log(respFraction);
 
           if (respFraction[1]) {
             var respFractionLen = respFraction[1].length;
 
             if (respFractionLen > this.precision) {
               completeNumber = Number(completeNumber).toFixed(this.precision);
-              console.log(completeNumber);
             }
             else {
 
               var oddOrEven = respFractionLen % 2;
               if (oddOrEven > 0 ) {
                 completeNumber = '' + completeNumber + '0';
-                console.log(completeNumber);
               }
             }
           }

--- a/money-input.html
+++ b/money-input.html
@@ -218,24 +218,7 @@ Custom property | Description | Default
           completeNumber = (integer + decFraction);
         }
 
-        console.log(this.value);
-        console.log(value);
-        console.log(decFraction);
-        console.log(integer);
-        console.log(completeNumber);
-        console.log('======');
-        console.log(this.precision);
-        console.log(multiplier);
-
-        console.log(signal + (("" + this.value).length >= this.precision));
-        console.log((this.value + Array(this.precision + 1).join("0")));
-
-        console.log('-------------------------------------------------------');
-
         this._formattedValue = completeNumber;
-
-//        this._formattedValue = signal + ((this.value).length >= this.precision ?
-//                this.value : (this.value + Array(this.precision + 1).join("0")));
       },
 
       _valueChange: function(){

--- a/money-input.html
+++ b/money-input.html
@@ -213,15 +213,29 @@ Custom property | Description | Default
           integer = Number(this.value) - Number(decFraction);
           completeNumber = (integer + decFraction);
 
+          console.log(completeNumber);
+
           completeNumber = completeNumber + '';
           var respFraction = completeNumber.split('.');
-          var respFractionLen = respFraction[1].length;
+          console.log(respFraction);
 
-          var oddOrEven = respFractionLen % 2;
+          if (respFraction[1]) {
+            var respFractionLen = respFraction[1].length;
 
-          if (oddOrEven > 0 ) {
-            completeNumber = '' + completeNumber + '0';
+            if (respFractionLen > this.precision) {
+              completeNumber = Number(completeNumber).toFixed(this.precision);
+              console.log(completeNumber);
+            }
+            else {
+
+              var oddOrEven = respFractionLen % 2;
+              if (oddOrEven > 0 ) {
+                completeNumber = '' + completeNumber + '0';
+                console.log(completeNumber);
+              }
+            }
           }
+
         }
 
         this._formattedValue = completeNumber;

--- a/money-input.html
+++ b/money-input.html
@@ -173,12 +173,18 @@ Custom property | Description | Default
 
       /** You can use this to re-render the input */
       renderElement: function(){
+        console.log('renderElement');
+
         this.$.input.invalid = false;
+
         if(this.value && !this._formattedValue) {
-          var signal = (""+this.value).indexOf("\-")>=0 ? "-" : "";
-          this._formattedValue = signal + (this.value.length >= this.precision ? this.value : (this.value + Array(this.precision + 1).join("0")));
+          console.log('from renderElement');
+          this._valuePreProcessing();
         }
+
         this._setValue = function (f) {
+          console.log('_setValue');
+
           if(this._formattedValue) {
             var signal = this._formattedValue.indexOf("\-") >= 0 ? "-" : "";
             this.set("value", signal + (parseFloat(this._removeUI(this._formattedValue)) / (Math.pow(10, this.precision))).toFixed(this.precision));
@@ -192,10 +198,54 @@ Custom property | Description | Default
         this._formattedValue = "";
       },
 
+      _valuePreProcessing: function() {
+        var signal = ("" + this.value).indexOf("\-") >= 0 ? "-" : "";
+
+        var multiplier = Math.pow(10, this.precision);
+        var value = (this.value * multiplier) / multiplier;
+        var fraction = value % 1;
+        var decFraction = (fraction * multiplier) / multiplier;
+
+        var integer = undefined;
+        var completeNumber = undefined;
+
+        if (decFraction == 0 && this.precision != 0) {
+          console.log('they fed me an Integer');
+          completeNumber = signal + value + ".00";
+        }
+        else {
+          integer = Number(this.value) - Number(decFraction);
+          completeNumber = (integer + decFraction);
+        }
+
+        console.log(this.value);
+        console.log(value);
+        console.log(decFraction);
+        console.log(integer);
+        console.log(completeNumber);
+        console.log('======');
+        console.log(this.precision);
+        console.log(multiplier);
+
+        console.log(signal + (("" + this.value).length >= this.precision));
+        console.log((this.value + Array(this.precision + 1).join("0")));
+
+        console.log('-------------------------------------------------------');
+
+        this._formattedValue = completeNumber;
+
+//        this._formattedValue = signal + ((this.value).length >= this.precision ?
+//                this.value : (this.value + Array(this.precision + 1).join("0")));
+      },
+
       _valueChange: function(){
-        if(this.value && this._formattedValue!= this.value) {
-          var signal = (""+this.value).indexOf("\-")>=0 ? "-" : "";
-          this._formattedValue = signal + ((""+this.value).length >= this.precision ? this.value : (this.value + Array(this.precision + 1).join("0")));
+        console.log('_valueChange');
+
+        if((this.value || this.value === 0 || this.value === '0') &&
+            (this._formattedValue!= this.value || this.value === 0 || this.value === '0')) {
+          console.log('from _valueChange');
+
+          this._valuePreProcessing();
         }
       },
 
@@ -223,15 +273,16 @@ Custom property | Description | Default
       _onValueChanged: function(){
         this.validate();
 
-        if (this._formattedValue === '' || (this._formattedValue === '0' && this.precision==0)) {
+        if (this._formattedValue === '' ||
+            (this._formattedValue === '0' && this.precision == 0)) {
           return;
         }
 
-        if(this.precision==0){
+        if(this.precision == 0){
           this._formattedValue = this._markAmount(this._removeUI(this._formattedValue));
           return;
         }
-        var signal = this._formattedValue.indexOf("\-")>=0 ? "-" : "";
+        var signal = ('' + this._formattedValue).indexOf("\-")>=0 ? "-" : "";
 
         if(this._removeUI(this._formattedValue).length<this.precision+1) {
           var dec = this._getDecimal(this._removeUI(this._formattedValue)), group;
@@ -256,11 +307,11 @@ Custom property | Description | Default
       },
 
       _removeUI: function(string){
-        return string.replace(/[^\d]*/g, '');
+        return ('' + string).replace(/[^\d]*/g, '');
       },
 
       _validate: function(value) {
-        var signal = value.indexOf("\-")>=0 ? "-" : "";
+        var signal = ('' + value).indexOf("\-")>=0 ? "-" : "";
         var n = parseFloat(signal+this._removeUI(value))/(Math.pow(10,this.precision));
 
         if(n>this.maxValue){

--- a/money-input.html
+++ b/money-input.html
@@ -207,12 +207,21 @@ Custom property | Description | Default
         var completeNumber = undefined;
 
         if (decFraction == 0 && this.precision != 0) {
-          //console.log('they fed me an Integer');
           completeNumber = signal + value + ".00";
         }
         else {
           integer = Number(this.value) - Number(decFraction);
           completeNumber = (integer + decFraction);
+
+          completeNumber = completeNumber + '';
+          var respFraction = completeNumber.split('.');
+          var respFractionLen = respFraction[1].length;
+
+          var oddOrEven = respFractionLen % 2;
+
+          if (oddOrEven > 0 ) {
+            completeNumber = '' + completeNumber + '0';
+          }
         }
 
         this._formattedValue = completeNumber;

--- a/money-input.html
+++ b/money-input.html
@@ -8,9 +8,9 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="bower_components/polymer/polymer.html">
-<link rel="import" href="bower_components/paper-input/paper-input.html">
-<link rel="import" href="bower_components/paper-input/paper-input-error.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../paper-input/paper-input.html">
+<link rel="import" href="../paper-input/paper-input-error.html">
 
 <!--
 `<money-input>` is a customizable input validator and mask for currency amounts.

--- a/money-input.html
+++ b/money-input.html
@@ -8,9 +8,9 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
-<link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../paper-input/paper-input.html">
-<link rel="import" href="../paper-input/paper-input-error.html">
+<link rel="import" href="bower_components/polymer/polymer.html">
+<link rel="import" href="bower_components/paper-input/paper-input.html">
+<link rel="import" href="bower_components/paper-input/paper-input-error.html">
 
 <!--
 `<money-input>` is a customizable input validator and mask for currency amounts.
@@ -47,6 +47,7 @@ Custom property | Description | Default
     <paper-input
             id="input"
             label="[[label]]"
+            no-label-float="[[noLabelFloat]]"
             required$="[[required]]"
             value="{{_formattedValue}}"
             name$="[[name]]"
@@ -98,6 +99,12 @@ Custom property | Description | Default
         label: {
           type: String,
           value: 'Amount'
+        },
+
+        /** Disables the floating label */
+        noLabelFloat: {
+          type: Boolean,
+          value: false
         },
 
         /** Presets field value notifies new values */


### PR DESCRIPTION
When the value of the field is 0 the actual code does not add the zero + decimal precision (e.g 0.00) to the field UI. A fix for that is provided here.

When the value of the field is an integer, the actual code takes the precision decimals from the integer.
For example, if the original value is 600, and the precision is set to 2, what will be displayed is 6.00.
A fix for this issue is also provided here.

Also added more samples to the demo/index.html file.

Note: 
Code from the pull request #6 also added here.
No need to accept pull request #6 if this pull request is accepted.
